### PR TITLE
Experimental

### DIFF
--- a/lib/timer/timer.publish.js
+++ b/lib/timer/timer.publish.js
@@ -46,7 +46,7 @@
 		// Hover
 		manager.delegate('div.timeline', 'mouseover.timer', function(event) {
 			var timeline = $(this),
-				selected = getTime(timeline, event.pageX);
+				selected = getTime(timeline, event.pageX),
 				date = new Date(),
 				time;
 
@@ -242,7 +242,7 @@
 		// Get time
 		var getTime = function(timeline, position) {
 			var left = timeline.offset().left,
-				width = timeline.width();
+				width = timeline.width(),
 				selection = Math.min(Math.max(position - left, 0), width - 1),
 				time = selection / width * 24,
 				hours = Math.floor(time);
@@ -275,7 +275,7 @@
 			var timeline = range.parent(),
 				time = range.find('code'),
 				length = timeline.width(),
-				left = range.position().left,
+				left = range.position() ? range.position().left : 0,
 				width = range.width();
 				
 			// Set position


### PR DESCRIPTION
- two commas instead of semicolons (we don't want global vars)
- and a quick fix in setTimerPosition() (I didn't have the timer setting set) 
