### PR TITLE
Improve the `prepareImportValue` 

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -15,6 +15,8 @@
 		require_once(EXTENSIONS . '/datetime/lib/calendar/class.calendar.php');
 	}
 
+	require_once TOOLKIT . '/fields/field.date.php';
+
 	Class fieldDatetime extends Field {
 
 		const RANGE = 1;


### PR DESCRIPTION
I had a use case where I need to import a start/end date using the XMLImporter.

I was able to use `concat(start, ' to ' end)` as the XPath and then use the PHP helper to split on `' to '`. This then results in the XMLImporter outputting an array of an array.

The `prepareImportValue` function didn't like that very much, but with this PR, it will happily handle input as string, array, or array of array (single array)!
