### PR TITLE
Requirement-check not working with symphony 2.3.2

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -1,11 +1,11 @@
 <?php
 
 	/**
-	* @package datetime
-	*/
+	 * @package datetime
+	 */
 	/**
-	* This field provides an interface to manage single or multiple dates as well as date ranges.
-	*/
+	 * This field provides an interface to manage single or multiple dates as well as date ranges.
+	 */
 	if(!defined('__IN_SYMPHONY__')) die('<h2>Symphony Error</h2><p>You cannot directly access this file</p>');
 
 	require_once TOOLKIT . '/fields/field.date.php';


### PR DESCRIPTION
_Re-submitting against development branch on base repo (still learning git[hub], sorry ;))._

After checking why I couldn't save a section entry without adding an optional date (always getting the required-field error message) and checking the field settings array I found the check of the field's required-setting (in method "checkPostFieldData") to be faulty and fixed it.
I also changed the relational operator to type-comparing (===) in all conditionals to avoid other unforeseen effects and int-casted numeric field-settings at the same time if necessary.
