### PR TITLE
Add end date as well to sorting SQL.

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -770,10 +770,10 @@
 			// times in the SQL, but is actually the same entry.
 			if(!preg_match('/`t' . $field_id . '`/', $joins)) {
 				$joins .= "LEFT OUTER JOIN `tbl_entries_data_" . $field_id . "` AS `ed` ON (`e`.`id` = `ed`.`entry_id`) ";
-				$sort = 'ORDER BY ' . (in_array(strtolower($order), array('random', 'rand')) ? 'RAND()' : "`ed`.`start` $order");
+				$sort = 'ORDER BY ' . (in_array(strtolower($order), array('random', 'rand')) ? 'RAND()' : "`ed`.`start`, `ed`.`end` $order");
 			}
 			else {
-				$sort = 'ORDER BY ' . (in_array(strtolower($order), array('random', 'rand')) ? 'RAND()' : "`t" . $field_id . "`.`start` $order");
+				$sort = 'ORDER BY ' . (in_array(strtolower($order), array('random', 'rand')) ? 'RAND()' : "`t$field_id`.`start`, `t$field_id`.`end` $order");
 			}
 		}
 


### PR DESCRIPTION
Given these dates (this is what the user sees in UI):

```
Entry #1
start: DD.MM.YYYY - 20:00
end: DD.MM.YYYY - 21:00

Entry #2
start: DD.MM.YYYY - 20:00
```

In database they're stored like this (end date is automatically set to start date, very good thing):

```
start: DD.MM.YYYY - 20:00
end: DD.MM.YYYY - 21:00

start: DD.MM.YYYY - 20:00
end: DD.MM.YYYY - 20:00
```

In this case, a DS with sorting for this field will return entries in this order:

```
Entry #1
Entry #2
```

This is not true, because `Entry #2` is earlier than `Entry #1` (NB: same start, but `Entry #2.end` < `Entry #1.end`). With this patch the sorting order takes into account the end date as well thus returning correct order:

```
Entry #2
Entry #1
```

Thanks!
