### PR TITLE
Add end date to sorting SQL only when order is ASC

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -762,18 +762,39 @@
 		Sorting:
 	-------------------------------------------------------------------------*/
 
-		function buildSortingSQL(&$joins, &$where, &$sort, $order='ASC') {
-			$field_id = $this->get('id');
+		function buildSortingSQL(&$joins, &$where, &$sort, $order = 'ASC'){
+			$field_id = $this->get( 'id' );
+			$order    = strtolower( $order );
 
 			// If we already have a JOIN to the entry table, don't create another one,
 			// this prevents issues where an entry with multiple dates is returned multiple
 			// times in the SQL, but is actually the same entry.
-			if(!preg_match('/`t' . $field_id . '`/', $joins)) {
-				$joins .= "LEFT OUTER JOIN `tbl_entries_data_" . $field_id . "` AS `ed` ON (`e`.`id` = `ed`.`entry_id`) ";
-				$sort = 'ORDER BY ' . (in_array(strtolower($order), array('random', 'rand')) ? 'RAND()' : "`ed`.`start`, `ed`.`end` $order");
+			if( !preg_match( '/`t'.$field_id.'`/', $joins ) ){
+				$joins .= "LEFT OUTER JOIN `tbl_entries_data_".$field_id."` AS `ed` ON (`e`.`id` = `ed`.`entry_id`) ";
+				$sort = 'ORDER BY ';
+
+				if( in_array( $order, array('random', 'rand') ) ){
+					$sort .= 'RAND()';
+				}
+				elseif( $order === 'asc' ){
+					$sort .= "`ed`.`start`, `ed`.`end` $order";
+				}
+				else{
+					$sort .= "`ed`.`start` $order";
+				}
 			}
-			else {
-				$sort = 'ORDER BY ' . (in_array(strtolower($order), array('random', 'rand')) ? 'RAND()' : "`t$field_id`.`start`, `t$field_id`.`end` $order");
+			else{
+				$sort = 'ORDER BY ';
+
+				if( in_array( $order, array('random', 'rand') ) ){
+					$sort .= 'RAND()';
+				}
+				elseif( $order === 'asc' ){
+					$sort .= "`t$field_id`.`start`, `t$field_id`.`end` $order";
+				}
+				else{
+					$sort .= "`t$field_id`.`start` $order";
+				}
 			}
 		}
 


### PR DESCRIPTION
With regards to #141. After merging #141, it seems the sorting doesn't work at all when order is set to DESC.

This patch adds `end` date to sorting only when order is ASC.

As result, `$order = 'DESC'` works and `$order = 'ASC'` works as described in #141.
