### PR TITLE
Replace wrapFormElementWithError() for 2.4

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -517,7 +517,7 @@
 			// Append Duplicator
 			$duplicator->appendChild($list);
 			if(!is_null($flagWithError)) {
-				$wrapper->appendChild(Widget::wrapFormElementWithError($duplicator, $flagWithError));
+				$wrapper->appendChild(Widget::Error($duplicator, $flagWithError));
 			}
 			else {
 				$wrapper->appendChild($duplicator);


### PR DESCRIPTION
Widget::wrapFormElementWithError() is depreciated from 2.4 of Symphony.
Updated to use Widget::Error(). As per [Issue #150](https://github.com/hananils/datetime/issues/150).
