### PR TITLE
Update for symphony 2.4 compatibility

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -114,7 +114,10 @@
 
 			// Add language strings to configuration
 			Symphony::Configuration()->set('english', $this->languages['english'], 'datetime');
-			Administration::instance()->saveConfig();
+			
+			Symphony::Configuration()->write();
+			//Old code : Administration::instance()->saveConfig();
+			
 
 			// Report status
 			if(in_array(false, $status, true)) {


### PR DESCRIPTION
From the migration guide : Administration::instance()->saveConfig has been removed, use Symphony::Configuration()->write();
