### PR TITLE
Change configuration save method to support 2.4

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -114,7 +114,8 @@
 
 			// Add language strings to configuration
 			Symphony::Configuration()->set('english', $this->languages['english'], 'datetime');
-			Administration::instance()->saveConfig();
+			Symphony::Configuration()->write();
+			//Administration::instance()->saveConfig();
 
 			// Report status
 			if(in_array(false, $status, true)) {


### PR DESCRIPTION
Replaced `Administration::instance()->saveConfig();` with `Symphony::Configuration()->write();`, as per the [migration guide](https://github.com/symphonycms/symphony-2/wiki/Migration-Guide-to-2.4-for-Developers#functions)
