### PR TITLE
Make sure 00:00:00 is saved when time is disabled

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -545,7 +545,7 @@
 				if(!empty($data['start'][$i])) {
 
 					// Parse start date
-					$parsed = Calendar::formatDate($data['start'][$i], true, 'Y-m-d H:i:s');
+					$parsed = $this->parseDateTime($data['start'][$i]);
 					$result['start'][] = $parsed['date'];
 
 					// Empty end date
@@ -555,7 +555,7 @@
 
 					// Specific end date
 					else {
-						$parsed = Calendar::formatDate($data['end'][$i], true, 'Y-m-d H:i:s');
+						$parsed = $this->parseDateTime($data['end'][$i]);
 						$result['end'][] = $parsed['date'];
 					}
 				}
@@ -568,6 +568,16 @@
 			else {
 				return $result;
 			}
+		}
+
+		public function parseDateTime($dateString) {
+			$dateFormat = 'Y-m-d';
+			$timeFormat = 'H:i:s';
+			$format = !$this->get('time')
+						? "$dateFormat 00:00:00"
+						: "$dateFormat $timeFormat";
+
+			return Calendar::formatDate($dateString, true, $format);
 		}
 
 	/*-------------------------------------------------------------------------


### PR DESCRIPTION
This change makes sure that the time is always midnight (00:00:00) when
the field setting 'time' is set to 0.

This change will also simplify filtering with 'now' when time is
disabled.

It introduce the method `parseDateTime` in order to acheive it without
code duplication. This method handles the proper date format according
to the field's setting.

Fixes #159 

@nilshoerrmann Can you please review and approve, I'll do the rest. Thanks.
