### PR TITLE
Fix for buildingSortingSelectSQL

### DIFF
--- a/fields/field.datetime.php
+++ b/fields/field.datetime.php
@@ -871,7 +871,7 @@
 				return null;
 			}
 			$field_id = $this->get('id');
-			if (!preg_match( '/`t'.$field_id.'`/', $this->lastWhere)) {
+			if (!preg_match( '/`t'.$field_id.'`/', $sort)) {
 				return '`ed`.`start`, `ed`.`end`';
 			}
 			return "`t$field_id`.`start`, `t$field_id`.`end`";


### PR DESCRIPTION
The preg_match to check if the alias needs to be changed should be on the sort value and not on the last_where which contains too much information.